### PR TITLE
Can't change page handle when page translation is deleted

### DIFF
--- a/lib/class.TFolder.php
+++ b/lib/class.TFolder.php
@@ -244,6 +244,11 @@
 		public function changeTranslationHandle($old_handle, $new_handle){
 			$translation = $this->translations[$old_handle];
 
+			if(!is_object($translation))
+			{
+				return false;
+			}
+
 			if( !$translation->setHandle($new_handle) ){
 				return false;
 			}

--- a/lib/class.TManager.php
+++ b/lib/class.TManager.php
@@ -462,9 +462,12 @@
 			else{
 				foreach( $changed as $translation ){
 					/* @var $translation Translation */
-					$translation->delete();
-					$translation->setHandle($old_handle);
-					$translation->setName($old_handle);
+					if(is_object($translation))
+					{
+						$translation->delete();
+						$translation->setHandle($old_handle);
+						$translation->setName($old_handle);
+					}
 				}
 			}
 


### PR DESCRIPTION
When a pages translation is deleted, and you want to change the handle of the specific page, an error is thrown. This fixes that simply by checking if an object is returned on two critical moments.
