### PR TITLE
Optional Translations

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -25,6 +25,9 @@
 	</authors>
 
 	<releases>
+		<release version="1.7.2" date="2013-07-19" min="2.3"><![CDATA[
+			* Added a config option to disable Translations
+		]]></release>
 		<release version="1.7.1" date="2012-09-09" min="2.3"><![CDATA[
 			* Added a new delegate to modify settings at initialization.
 			* Fixed error when creating new translation if no languages are set.


### PR DESCRIPTION
This pull requests add an option in the config to enable/disable translations.

The translations system is not always used and sometimes one might prefer to use a Symphony Section. In this case the translations component is utilizing resources making the system uselessly inefficient. Thus it takes care of disabling the translations parsing when translations are not enabled with the new config option.

This change + disabling translations made my symphony install(s) with multiple pages quite a bit faster.
