### PR TITLE
Fixed a compatibility issue with FL:Languages data source

### DIFF
--- a/data-sources/data.fl_languages.php
+++ b/data-sources/data.fl_languages.php
@@ -25,7 +25,7 @@
 			return false;
 		}
 
-		public function grab(&$param_pool = null) {
+		public function execute(array &$param_pool = null) {
 			$result = new XMLElement('fl-languages');
 
 			$main_lang  = FLang::getMainLang();

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -33,6 +33,9 @@
 	</dependencies>
 
 	<releases>
+		<release version="2.6.4" data="2016-01-31" min="2.3.4" max="2.6.x"><![CDATA[
+			* Fixed a compatibility problem with FL:Languages data source.
+		]]></release>
 		<release version="2.6.3" date="2015-10-09" min="2.3.4" max="2.6.x"><![CDATA[
 			* Reverted c631bbb and made sure that page alerts won't crash
 		]]></release>


### PR DESCRIPTION
Datasource::grab(&$param_pool) was changed to Datasource::execute(array &$param_pool) in 2.3.1.